### PR TITLE
ValidationException description is null

### DIFF
--- a/commons-model/src/main/java/com/appjars/saturn/exception/BaseException.java
+++ b/commons-model/src/main/java/com/appjars/saturn/exception/BaseException.java
@@ -72,7 +72,7 @@ public abstract class BaseException extends RuntimeException {
 		this.messageKeyValues = messageKeyValues;
 	}
 
-	public <T extends ErrorDescription> BaseException(Throwable cause, T error) {
+	public BaseException(Throwable cause, ErrorDescription error) {
 		super(cause);
 		this.messageKey = error.getMessageKey();
 		this.messageKeyValues = error.getMessageKeyValues();

--- a/commons-model/src/main/java/com/appjars/saturn/exception/BaseException.java
+++ b/commons-model/src/main/java/com/appjars/saturn/exception/BaseException.java
@@ -55,7 +55,7 @@ public abstract class BaseException extends RuntimeException {
 	}
 
 	public BaseException(String messageKey) {
-		super();
+		super(messageKey);
 		this.messageKey = messageKey;
 		messageKeyValues = null;
 	}
@@ -67,13 +67,13 @@ public abstract class BaseException extends RuntimeException {
 	}
 
 	public BaseException(String messageKey, Serializable... messageKeyValues) {
-		super();
+		super(messageKey);
 		this.messageKey = messageKey;
 		this.messageKeyValues = messageKeyValues;
 	}
 
 	public BaseException(Throwable cause, ErrorDescription error) {
-		super(cause);
+		super(error.getMessageKey(), cause);
 		this.messageKey = error.getMessageKey();
 		this.messageKeyValues = error.getMessageKeyValues();
 	}
@@ -83,6 +83,7 @@ public abstract class BaseException extends RuntimeException {
 		this.errors = errors;
 		messageKey = DEFAULT_MESSAGE_KEY;
 		messageKeyValues = null;
+		fillSuppressed();
 	}
 
 	public BaseException(List<ErrorDescription> errors) {
@@ -90,7 +91,20 @@ public abstract class BaseException extends RuntimeException {
 		this.errors = errors;
 		messageKey = DEFAULT_MESSAGE_KEY;
 		messageKeyValues = null;
+		fillSuppressed();
 	}
+
+	private void fillSuppressed() {
+		if (errors!=null) {
+			for (ErrorDescription error : errors) {
+				BaseException e = newInstance(error);
+				e.setStackTrace(new StackTraceElement[0]);
+				addSuppressed(e);
+			}
+		}
+	}
+	
+	protected abstract BaseException newInstance(ErrorDescription error);
 
 	public Object[] getMessageKeyValues() {
 		return messageKeyValues;

--- a/commons-model/src/main/java/com/appjars/saturn/exception/ServiceException.java
+++ b/commons-model/src/main/java/com/appjars/saturn/exception/ServiceException.java
@@ -57,7 +57,7 @@ public class ServiceException extends BaseException {
 		super(cause, messageKey, messageKeyValues);
 	}
 
-	public <T extends ErrorDescription> ServiceException(Throwable cause, T error) {
+	public ServiceException(Throwable cause, ErrorDescription error) {
 		super(cause, error);
 	}
 

--- a/commons-model/src/main/java/com/appjars/saturn/exception/ServiceException.java
+++ b/commons-model/src/main/java/com/appjars/saturn/exception/ServiceException.java
@@ -64,5 +64,10 @@ public class ServiceException extends BaseException {
 	public ServiceException(Throwable cause) {
 		super(cause);
 	}
+	
+	@Override
+	protected BaseException newInstance(ErrorDescription error) {
+		return new ServiceException(null, error);
+	}
 
 }

--- a/commons-model/src/main/java/com/appjars/saturn/validation/ValidationException.java
+++ b/commons-model/src/main/java/com/appjars/saturn/validation/ValidationException.java
@@ -58,7 +58,7 @@ public class ValidationException extends BaseException {
 		super(cause, messageKey, messageKeyValues);
 	}
 
-	public <T extends ErrorDescription> ValidationException(Throwable cause, T error) {
+	public ValidationException(Throwable cause, ErrorDescription error) {
 		super(cause, error);
 	}
 

--- a/commons-model/src/main/java/com/appjars/saturn/validation/ValidationException.java
+++ b/commons-model/src/main/java/com/appjars/saturn/validation/ValidationException.java
@@ -66,4 +66,9 @@ public class ValidationException extends BaseException {
 		super(cause);
 	}
 
+	@Override
+	protected BaseException newInstance(ErrorDescription error) {
+		return new ValidationException(null, error);
+	}
+	
 }


### PR DESCRIPTION
Sometimes a `ValidationException` has a messageKey (instead of a `Throwable.getMessage()`).  Sometimes it has a list of error descriptions, and each ErrorDescription has a message key. I refactored the constructors so that at least the message keys are somehow preserved in a stacktrace.

```
throw new ValidationException("error.message");
```

> Exception in thread "main" com.appjars.saturn.validation.ValidationException: error.message
> 	at com.appjars.saturn.exception.AA.main(AA.java:11)
> 

```
throw new ValidationException(null, new ErrorDescription("some.error"));
```

> Exception in thread "main" com.appjars.saturn.validation.ValidationException: some.error
> 	at com.appjars.saturn.exception.AA.main(AA.java:11)
> 

```
throw new ValidationException(null, new ErrorDescription("some.error"));
```

> Exception in thread "main" com.appjars.saturn.validation.ValidationException: some.error
> 	at com.appjars.saturn.exception.AA.main(AA.java:11)
> Caused by: java.lang.RuntimeException: foo
> 	... 1 more
> 

```
throw new ValidationException(Arrays.asList(new ErrorDescription("some.error"), new ErrorDescription("other.error")));
```

> Exception in thread "main" com.appjars.saturn.validation.ValidationException
> 	at com.appjars.saturn.exception.AA.main(AA.java:12)
> 	Suppressed: com.appjars.saturn.validation.ValidationException: some.error
> 	Suppressed: com.appjars.saturn.validation.ValidationException: other.error
> 