### PR TITLE
ci: add dependency needed by the javadoc plugin

### DIFF
--- a/commons-business-impl/pom.xml
+++ b/commons-business-impl/pom.xml
@@ -48,6 +48,12 @@
 		    <artifactId>lombok</artifactId>
 		    <scope>provided</scope>
 		</dependency>		
+		<dependency>
+			<groupId>javax.interceptor</groupId>
+			<artifactId>javax.interceptor-api</artifactId>
+			<version>1.2.2</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 </project>


### PR DESCRIPTION
`javax.transaction.Transactional` is annotated with `javax.interceptor.InterceptorBinding`, which is missing in classpath unless explicitly declared in dependencies. As a result JDK8 javadoc tool fails to process the sources (if any of them are annotated with `@Transactional`).

See https://stackoverflow.com/a/28755606/1297272