### PR TITLE
docs: configure javadoc groups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,5 +110,37 @@
             </plugin>
         </plugins>
     </build>
-	
+
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+						<groups>
+						  <group>
+							<title>commons-data</title>
+							<packages>com.appjars.saturn.dao</packages>
+						  </group>
+						  <group>
+							<title>commons-data-impl</title>
+							<packages>com.appjars.saturn.dao.jpa</packages>
+						  </group>
+						  <group>
+							<title>commons-business</title>
+							<packages>com.appjars.saturn.service</packages>
+						  </group>
+						  <group>
+							<title>commons-business-impl</title>
+							<packages>com.appjars.saturn.service*</packages>
+						  </group>
+						  <group>
+							<title>commons-model</title>
+							<packages>com.appjars.saturn.model*:com.appjars.saturn.exception:com.appjars.saturn.validation</packages>
+						  </group>
+						</groups>
+				</configuration>
+			</plugin>
+		</plugins>
+	</reporting>
 </project>


### PR DESCRIPTION
Group packages in the aggregate overview (https://docs.appjars.com/saturn/commons-backend/apidocs/index.html) by the containing module.
![image](https://user-images.githubusercontent.com/11554739/132865304-1aeef0df-c664-45eb-a0b1-d994da49c9b6.png)
