### PR TITLE
Add InvariantValidator and forCondition overload

### DIFF
--- a/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/CreationValidator.java
+++ b/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/CreationValidator.java
@@ -30,22 +30,21 @@ import com.appjars.saturn.validation.Validator;
 
 public interface CreationValidator<T> extends Validator<T> {
 
-	default CreationValidator<T> and(CreationValidator<T> then) {
-		return t -> {
-			List<ErrorDescription> result = this.validate(t);
-			if (result.isEmpty()) {
-				result = then.validate(t); 
-			}
-			return result;
-		};
-	}
+  default CreationValidator<T> and(CreationValidator<T> then) {
+    return t -> {
+      List<ErrorDescription> result = this.validate(t);
+      if (result.isEmpty()) {
+        result = then.validate(t); 
+      }
+      return result;
+    };
+  }
 
-	static <T> CreationValidator<T> forCondition(Predicate<T> predicate, Function<T, ErrorDescription> errorSupplier) {
-		Objects.requireNonNull(predicate);
-		Objects.requireNonNull(errorSupplier);
-		return t->predicate.test(t)?Validator.success():Collections.singletonList(errorSupplier.apply(t));
-	}
-	
+  static <T> CreationValidator<T> forCondition(Predicate<T> predicate, Function<T, ErrorDescription> errorSupplier) {
+    Objects.requireNonNull(predicate);
+    Objects.requireNonNull(errorSupplier);
+    return t->predicate.test(t)?Validator.success():Collections.singletonList(errorSupplier.apply(t));
+  }
+
 }
-
 

--- a/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/CreationValidator.java
+++ b/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/CreationValidator.java
@@ -46,5 +46,10 @@ public interface CreationValidator<T> extends Validator<T> {
     return t->predicate.test(t)?Validator.success():Collections.singletonList(errorSupplier.apply(t));
   }
 
+  static <T> CreationValidator<T> forCondition(Predicate<T> predicate, String messageKey) {
+    Objects.requireNonNull(messageKey);
+    return forCondition(predicate, t->new ErrorDescription(messageKey));
+  }
+
 }
 

--- a/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/DeletionValidator.java
+++ b/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/DeletionValidator.java
@@ -46,4 +46,9 @@ public interface DeletionValidator<T> extends Validator<T> {
     return t->predicate.test(t)?Validator.success():Collections.singletonList(errorSupplier.apply(t));
   }
 
+  static <T> DeletionValidator<T> forCondition(Predicate<T> predicate, String messageKey) {
+    Objects.requireNonNull(messageKey);
+    return forCondition(predicate, t->new ErrorDescription(messageKey));
+  }
+
 }

--- a/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/DeletionValidator.java
+++ b/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/DeletionValidator.java
@@ -30,20 +30,20 @@ import com.appjars.saturn.validation.Validator;
 
 public interface DeletionValidator<T> extends Validator<T> {
 
-	default DeletionValidator<T> and(DeletionValidator<T> then) {
-		return t -> {
-			List<ErrorDescription> result = this.validate(t);
-			if (result.isEmpty()) {
-				result = then.validate(t); 
-			}
-			return result;
-		};
-	}
+  default DeletionValidator<T> and(DeletionValidator<T> then) {
+    return t -> {
+      List<ErrorDescription> result = this.validate(t);
+      if (result.isEmpty()) {
+        result = then.validate(t); 
+      }
+      return result;
+    };
+  }
 
-	static <T> DeletionValidator<T> forCondition(Predicate<T> predicate, Function<T, ErrorDescription> errorSupplier) {
-		Objects.requireNonNull(predicate);
-		Objects.requireNonNull(errorSupplier);
-		return t->predicate.test(t)?Validator.success():Collections.singletonList(errorSupplier.apply(t));
-	}
-	
+  static <T> DeletionValidator<T> forCondition(Predicate<T> predicate, Function<T, ErrorDescription> errorSupplier) {
+    Objects.requireNonNull(predicate);
+    Objects.requireNonNull(errorSupplier);
+    return t->predicate.test(t)?Validator.success():Collections.singletonList(errorSupplier.apply(t));
+  }
+
 }

--- a/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/InvariantValidator.java
+++ b/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/InvariantValidator.java
@@ -28,4 +28,9 @@ public interface InvariantValidator<T> extends CreationValidator<T>, UpdateValid
     return t->predicate.test(t)?Validator.success():Collections.singletonList(errorSupplier.apply(t));
   }
 
+  static <T> InvariantValidator<T> forCondition(Predicate<T> predicate, String messageKey) {
+    Objects.requireNonNull(messageKey);
+    return forCondition(predicate, t->new ErrorDescription(messageKey));
+  }
+
 }

--- a/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/InvariantValidator.java
+++ b/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/InvariantValidator.java
@@ -1,0 +1,31 @@
+package com.appjars.saturn.service.validation;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import com.appjars.saturn.model.ErrorDescription;
+import com.appjars.saturn.service.validation.CreationValidator;
+import com.appjars.saturn.service.validation.UpdateValidator;
+import com.appjars.saturn.validation.Validator;
+
+public interface InvariantValidator<T> extends CreationValidator<T>, UpdateValidator<T> {
+
+  default InvariantValidator<T> and(InvariantValidator<T> then) {
+    return t -> {
+      List<ErrorDescription> result = this.validate(t);
+      if (result.isEmpty()) {
+        result = then.validate(t);
+      }
+      return result;
+    };
+  }
+
+  static <T> InvariantValidator<T> forCondition(Predicate<T> predicate, Function<T, ErrorDescription> errorSupplier) {
+    Objects.requireNonNull(predicate);
+    Objects.requireNonNull(errorSupplier);
+    return t->predicate.test(t)?Validator.success():Collections.singletonList(errorSupplier.apply(t));
+  }
+
+}

--- a/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/UpdateValidator.java
+++ b/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/UpdateValidator.java
@@ -30,20 +30,20 @@ import com.appjars.saturn.validation.Validator;
 
 public interface UpdateValidator<T> extends Validator<T> {
 
-	default UpdateValidator<T> and(UpdateValidator<T> then) {
-		return t -> {
-			List<ErrorDescription> result = this.validate(t);
-			if (result.isEmpty()) {
-				result = then.validate(t); 
-			}
-			return result;
-		};
-	}
-	
-	static <T> UpdateValidator<T> forCondition(Predicate<T> predicate, Function<T, ErrorDescription> errorSupplier) {
-		Objects.requireNonNull(predicate);
-		Objects.requireNonNull(errorSupplier);
-		return t->predicate.test(t)?Validator.success():Collections.singletonList(errorSupplier.apply(t));
-	}
-	
+  default UpdateValidator<T> and(UpdateValidator<T> then) {
+    return t -> {
+      List<ErrorDescription> result = this.validate(t);
+      if (result.isEmpty()) {
+        result = then.validate(t); 
+      }
+      return result;
+    };
+  }
+
+  static <T> UpdateValidator<T> forCondition(Predicate<T> predicate, Function<T, ErrorDescription> errorSupplier) {
+    Objects.requireNonNull(predicate);
+    Objects.requireNonNull(errorSupplier);
+    return t->predicate.test(t)?Validator.success():Collections.singletonList(errorSupplier.apply(t));
+  }
+
 }

--- a/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/UpdateValidator.java
+++ b/commons-business-impl/src/main/java/com/appjars/saturn/service/validation/UpdateValidator.java
@@ -46,4 +46,9 @@ public interface UpdateValidator<T> extends Validator<T> {
     return t->predicate.test(t)?Validator.success():Collections.singletonList(errorSupplier.apply(t));
   }
 
+  static <T> UpdateValidator<T> forCondition(Predicate<T> predicate, String messageKey) {
+    Objects.requireNonNull(messageKey);
+    return forCondition(predicate, t->new ErrorDescription(messageKey));
+  }
+
 }


### PR DESCRIPTION
- Add an `InvariantValidator` (i.e. a `Validator` that is both a `CreationValidator` and an `UpdateValidator`, so that validation rules that apply both at creation and modification time do not have to be specified twice)

- Add methods `forCondition(Predicate,String)` so that it's easier to create a validator with a constant message key.

Example: use
```
@Override
public List<Validator<Foo>> getValidators() {
  return List.of(
    InvariantValidator.forCondition(this::validateFoo, "...");
  );
}
```

instead of:
```
@Override
public List<Validator<Foo>> getValidators() {
  return List.of(
    CreationValidator.forCondition(this::validateFoo,   t -> new ErrorDescription("...")),
    UpdateValidator.forCondition(this::validateFoo,   t -> new ErrorDescription("..."));
  );
}
```