### PR TITLE
Add toBuilder = true configuration in BaseEntity SuperBuilder annotation

### DIFF
--- a/commons-model/src/main/java/com/appjars/saturn/model/BaseEntity.java
+++ b/commons-model/src/main/java/com/appjars/saturn/model/BaseEntity.java
@@ -29,7 +29,7 @@ import lombok.experimental.SuperBuilder;
  *
  * @param <K>
  */
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 @NoArgsConstructor
 public abstract class BaseEntity<K> implements Identifiable<K> {
 


### PR DESCRIPTION
Setting @SuperBuilder(toBuilder = true) generate an instance method in your class called toBuilder(); it creates a new builder that starts out with all the values of this instance. So, if there is the need of instantiating an entity that is almost the same of another, but that differs with he original with only a few attribute values, you don't need to use the builder and set the repeated values by hand.
In order to be used, toBuilder requires that all superclasses also have toBuilder = true.